### PR TITLE
add ability to silent cron on success

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class poudriere (
   $http_proxy             = '',
   $ftp_proxy              = '',
   $cron_enable            = false,
+  $cron_always_mail       = false,
   $cron_interval          = {minute => 0, hour => 22, monthday => '*', month => '*', week => '*'},
   $environments           = {},
   $portstrees             = {},
@@ -81,9 +82,10 @@ class poudriere (
 
   # Create default portstree
   poudriere::portstree { 'default':
-    fetch_method  => $port_fetch_method,
-    cron_enable   => $cron_enable,
-    cron_interval => $cron_interval,
+    fetch_method     => $port_fetch_method,
+    cron_enable      => $cron_enable,
+    cron_always_mail => $cron_always_mail,
+    cron_interval    => $cron_interval,
   }
 
   # Create environments


### PR DESCRIPTION
By default the poudriere command is pretty noisy and if cron is enabled you receive an email every time the cron job runs.  I think most operators would only like to recive an email if the command fails.  This pull request adds the parameter $cron_always_mail.  if this parameter is false (default) then the cron job will only mail the output if the command exited with a none 0 value.  If this parameter is true we get the current behaviour.

I also removed the path from the command.  I think most people will already set there path amnd other environment settings in the site.pp with something like the following

```puppet
Cron {
  environment => [
    'MAILTO=noc@example.com',
    'PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/games:/usr/local/sbin:/usr/local/bin'
    ]
}
```

