### PR TITLE
Fix ccache option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 Gemfile.lock
 .bundle
 pkg/

--- a/templates/poudriere.conf.erb
+++ b/templates/poudriere.conf.erb
@@ -122,6 +122,9 @@ PKG_REPO_SIGNING_KEY=<%= @pkg_repo_signing_key %>
 # It will be mounted into the jail and be shared among all jails.
 #CCACHE_DIR=/var/cache/ccache
 #
+<% if @ccache_enable and @ccache_dir != '' -%>
+CCACHE_DIR=<%= @ccache_dir %>
+<% end -%>
 
 # parallel build support.
 #


### PR DESCRIPTION
Although there were `$ccache_enable` and `$ccache_dir` options, `ccache` was never properly used as `CCACHE_DIR` was left undefined in `poudriere.conf`.

This PR remedies that.