### PR TITLE
Drop beaker from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,3 @@ group :development do
   gem "guard-rake"
 end
 
-group :system_tests do
-  gem "beaker"
-  gem "beaker-rspec"
-end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ group :test do
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
+  gem 'json', '~>1.0' if RUBY_VERSION =~ /^1\.9\.3.*$/
+  gem 'json_pure', '~>1.0' if RUBY_VERSION =~ /^1\.9\.3.*$/
 end
 
 group :development do


### PR DESCRIPTION
I've not used beaker ever, and there are no integration tests in this
module.  Dropping the gem here to avoid noise.