### PR TITLE
Fix detection of created jails

### DIFF
--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -80,7 +80,7 @@ define poudriere::env (
     exec { "poudriere-jail-${jail}":
       command => "/usr/local/bin/poudriere jail -c -j ${jail} -v ${version} -a ${arch} -p ${portstree}",
       require => Poudriere::Portstree[$portstree],
-      creates => "${poudriere::poudriere_base}/jails/${jail}/",
+      creates => regsubst("${poudriere::poudriere_base}/jails/${jail}/", ':', '_', 'G'),
       timeout => 3600,
     }
   } else {


### PR DESCRIPTION
The jails names have the ```:``` replaced with ```-``` so this change makes it look for the correct directory.